### PR TITLE
sample_c5の目標輝度値の計算方法の修正

### DIFF
--- a/sdk/workspace/sample_c5/LineTracer/LineTracer.c
+++ b/sdk/workspace/sample_c5/LineTracer/LineTracer.c
@@ -30,7 +30,7 @@ static int16_t steering_amount_calculation(void){
     rgb_raw_t rgb_val;           /* カラーセンサ取得値 */
 
     /* 目標輝度値の計算 */
-    target_brightness = (WHITE_BRIGHTNESS - BLACK_BRIGHTNESS) / 2;
+    target_brightness = (WHITE_BRIGHTNESS + BLACK_BRIGHTNESS) / 2;
 
     /* カラーセンサ値の取得 */
     ev3_color_sensor_get_rgb_raw(color_sensor, &rgb_val);


### PR DESCRIPTION
平山（東北地区技術委員）です。
sample_c5を実機で動かしたときに本件に気がつきました。
`LineTracer/LineTracer.h`のカラーセンサの輝度設定をいじってもライントレースの動作にならないため、変だな、と思って、調べたところ、`LineTracer/LineTracer.c`の目標輝度値の計算方法に不具合を見つけました。
`target_brightness`は、`WHITE_BRIGHTNESS`(白の輝度値)と`BLACK_BRIGHTNESS`(黒の輝度値)の中間の値(平均値)に設定するものだと思われますので、演算としては差ではなく正しくは和にするところと判断しました。

この修正をして、実機のカラーセンサに合わせて輝度設定をしたところ、ライントレースするようになりました。
修正をご検討ください。