### PR TITLE
Fix the direction of rotation of the motors.

### DIFF
--- a/sdk/workspace/sample_c5_spike/LineTracer/LineTracer.c
+++ b/sdk/workspace/sample_c5_spike/LineTracer/LineTracer.c
@@ -21,8 +21,8 @@ void LineTracer_Configure(pbio_port_id_t left_motor_port, pbio_port_id_t right_m
   fg_left_motor   = pup_motor_get_device(left_motor_port);
   fg_right_motor   = pup_motor_get_device(right_motor_port);  
 
-  pup_motor_setup(fg_left_motor,PUP_DIRECTION_CLOCKWISE,true);
-  pup_motor_setup(fg_right_motor,PUP_DIRECTION_COUNTERCLOCKWISE,true);  
+  pup_motor_setup(fg_left_motor,PUP_DIRECTION_COUNTERCLOCKWISE,true);
+  pup_motor_setup(fg_right_motor,PUP_DIRECTION_CLOCKWISE,true);  
 
 }
 


### PR DESCRIPTION
東北_平山(技術委員)です。
RasPike-ARTモードのsample_c5_spikeを試しました。
公式の走行体組立図のケーブル配線だと、モータの回転が逆でロボットが後ろに進んでしまいます。
LineTracer/LineTracer.cのLineTracer_Configure関数の回転方向を逆に指定しなおすと、前に進んで、ライントレースしました。